### PR TITLE
Update @types/node@latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",
-    "@types/node": "^14.14.35",
+    "@types/node": "^15.0.1",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
     "esbuild": "^0.11.11",


### PR DESCRIPTION
Fixes #3

If merged, this PR updates the version of `@types/node` to `15.0.1` which is latest.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR  (**Not Applicable**)
